### PR TITLE
Fix installer prompts and sudo usage

### DIFF
--- a/function
+++ b/function
@@ -106,7 +106,7 @@ function check_distro(){ # Vérifie si la distribution est pris en compte pour l
             if compatible "$VERSION_ID" DEBIAN_VERSIONS || compatible "$VERSION_ID" UBUNTU_VERSIONS || compatible "$VERSION_ID" ALMA_VERSIONS || compatible "$VERSION_ID" CENTOS_VERSIONS || compatible "$VERSION_ID" ROCKY_VERSIONS || compatible "$VERSION_ID" REDHAT_VERSIONS; then
                 info "$MSG_DISTRO_OK"
             else
-                warn "MSG_DISTRO_NONOK"
+                warn "$MSG_DISTRO_NONOK"
                 warn "$MSG_FORCE_DISTRO"
                 info "$MSG_FORCE_DISTRO_QUESTION"
                 read -r RESPONSE
@@ -119,7 +119,7 @@ function check_distro(){ # Vérifie si la distribution est pris en compte pour l
                         exit 1
                         ;;
                     *)
-                        warn "MSG_INVALID_ANSWER"
+                        warn "$MSG_INVALID_ANSWER"
                         exit 1
                         ;;
                 esac
@@ -144,10 +144,10 @@ function check_install(){ # Vérifie si GLPI est installé ou pas
             info "$MSG_GLPI_UPGRADE"
             read -r MaJ
             case "$MaJ" in
-                "O|o|Y|y")
+                [OoYy])
                     update
                     exit 0;;
-                "N"|"n")
+                [Nn])
                     info "$MSG_EXIT"
                     efface_script
                     exit 0;;
@@ -484,16 +484,16 @@ function maintenance(){ # Activé ou déactivé le mode maintenance (1 ou 0)
     if [ "$1" == "1" ]; then
         warn "$MSG_ACTIVE_SERVICE"
         if [[ "${ID}" =~ ^(debian|ubuntu)$ ]]; then
-            sudo www-data php "${REP_GLPI}"bin/console glpi:maintenance:enable 
+            sudo -u www-data php "${REP_GLPI}"bin/console glpi:maintenance:enable 
         elif [[ "${ID}" =~ ^(almalinux|centos|rocky|rhel)$ ]]; then
-            sudo nginx php "${REP_GLPI}"bin/console glpi:maintenance:enable 
+            sudo -u nginx php "${REP_GLPI}"bin/console glpi:maintenance:enable 
         fi
     elif [ "$1" == "0" ]; then
         info "$MSG_DEACTIVE_SERVICE"
         if [[ "${ID}" =~ ^(debian|ubuntu)$ ]]; then
-            sudo www-data php "${REP_GLPI}"bin/console glpi:maintenance:disable 
+            sudo -u www-data php "${REP_GLPI}"bin/console glpi:maintenance:disable 
         elif [[ "${ID}" =~ ^(almalinux|centos|rocky|rhel)$ ]]; then
-            sudo nginx php "${REP_GLPI}"bin/console glpi:maintenance:disable 
+            sudo -u nginx php "${REP_GLPI}"bin/console glpi:maintenance:disable 
         fi
     fi
 	sleep 2; }
@@ -529,14 +529,14 @@ EOF
 	info "$MSG_UPDATE_GLPI_DATABASE"
 	if [[ "${ID}" =~ ^(debian|ubuntu)$ ]]; then
 		chown -R www-data:www-data "${REP_GLPI}"
-		sudo www-data php "${REP_GLPI}"bin/console db:update --quiet --no-interaction --force 
+		sudo -u www-data php "${REP_GLPI}"bin/console db:update --quiet --no-interaction --force 
 	elif [[ "${ID}" =~ ^(almalinux|centos|rocky|rhel)$ ]]; then
 		chown -R nginx:nginx "${REP_GLPI}"
 		semanage fcontext -a -t httpd_sys_rw_content_t "${REP_GLPI}(/.*)?"
 		semanage fcontext -a -t httpd_sys_rw_content_t "${REP_GLPI}marketplace"
 		restorecon -Rv "${REP_GLPI}"
 		restorecon -Rv "${REP_GLPI}"marketplace
-		sudo nginx php "${REP_GLPI}"bin/console db:update --quiet --no-interaction --force 
+		sudo -u nginx php "${REP_GLPI}"bin/console db:update --quiet --no-interaction --force 
 	fi
 	info "$MSG_UPDATE_CLEAN"
 	rm -Rf "${REP_GLPI}"install/install.php


### PR DESCRIPTION
### Motivation
- Ensure installer uses localized message variables instead of literal strings for warnings and invalid-answer messages to show correct text to users.
- Make the upgrade prompt parsing robust by accepting common yes/no inputs reliably.
- Run GLPI maintenance and DB update commands under the correct web service user to avoid permission issues.

### Description
- Replaced literal warning strings like `"MSG_DISTRO_NONOK"` with the variable expansion `"$MSG_DISTRO_NONOK"` so localized messages are shown.
- Normalized prompt matching in `check_install` to use bracket-style patterns (`[OoYy]` and `[Nn]`) for `read` responses.
- Updated `maintenance` and `update_glpi` commands to invoke `sudo -u <user>` (e.g. `sudo -u www-data` and `sudo -u nginx`) when running `php` console commands so they execute as the appropriate web service user.
- Minor whitespace/newline fixes and applied the changes to the `function` script.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697350e96bb88332bf71124ccada1699)